### PR TITLE
Use shutil.move() instead of os.rename() to move test file

### DIFF
--- a/tool/clusterfuzz/reproducers.py
+++ b/tool/clusterfuzz/reproducers.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import time
 
@@ -148,7 +149,7 @@ def update_testcase_path_in_layout_test(
   new_testcase_path = os.path.join(
       source_directory, 'third_party', 'WebKit', 'LayoutTests',
       original_testcase_path[search_index + len(search_string):])
-  os.rename(testcase_path, new_testcase_path)
+  shutil.move(testcase_path, new_testcase_path)
   return new_testcase_path
 
 


### PR DESCRIPTION
os.rename() requires the source and dest on the same file system.
shutil.move() can handle files on different file systems.

For issue #359.