### PR TITLE
Upgrade pants to avoid crytography error

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 dependencies:
   override:
+    - sudo apt-get update
     - sudo apt-get install libpython2.7-dev
     - ./pants -V
   cache_directories:
@@ -8,20 +9,22 @@ test:
   override:
     - ./pants run tool:pylint
     - ./pants binary tool:clusterfuzz-`cat tool/clusterfuzz/resources/VERSION`
-    - ./pants test.pytest --coverage=1 tool:test
+    # `-p no:logging` is needed as a temporary workaround. See:
+    # https://github.com/pantsbuild/pants/issues/5310
+    - ./pants test.pytest --coverage=auto tool:test -- -p no:logging
     - ./pants run shared:coveralls -- --output=coverage_tool.json
 
     - ./pants run error:pylint
-    - ./pants test.pytest --coverage=1 error:test
+    - ./pants test.pytest --coverage=auto error:test -- -p no:logging
     - ./pants run shared:coveralls -- --merge=coverage_tool.json --output=coverage_tool.json
 
     - ./pants run ci/continuous_integration:pylint
     - ./pants binary ci/continuous_integration:daemon
-    - ./pants test.pytest --coverage=1 ci/continuous_integration:test
+    - ./pants test.pytest --coverage=auto ci/continuous_integration:test -- -p no:logging
     - ./pants run shared:coveralls -- --merge=coverage_tool.json --output=coverage_tool.json
 
     - ./pants run cmd-editor:pylint
-    - ./pants test.pytest --coverage=1 cmd-editor:test
+    - ./pants test.pytest --coverage=auto cmd-editor:test -- -p no:logging
     - ./pants run shared:coveralls -- --merge=coverage_tool.json
 
     - ./pants run butler:pylint

--- a/error/tests/error/error_test.py
+++ b/error/tests/error/error_test.py
@@ -59,6 +59,7 @@ class InitTest(helpers.ExtendedTestCase):
 
   def test_init(self):
     """Test init."""
+    print 'sdfdsf'
     error.MinimizationNotFinishedError()
     error.SanitizerNotProvidedError()
     error.ClusterFuzzError(500, 'resp', 'identity')

--- a/pants.ini
+++ b/pants.ini
@@ -1,2 +1,2 @@
 [GLOBAL]
-pants_version: 1.2.1
+pants_version: 1.3.0

--- a/tool/clusterfuzz/reproducers.py
+++ b/tool/clusterfuzz/reproducers.py
@@ -377,7 +377,7 @@ class BaseReproducer(object):
     # When running in regular mode, user would want to see screen, so
     # remove this argument.
     # TODO(tanin): refactor the condition to its own module function.
-    if (self.options.disable_xvfb and DISABLE_GL_DRAW_ARG in self.args):
+    if self.options.disable_xvfb and DISABLE_GL_DRAW_ARG in self.args:
       self.args = self.args.replace(' %s' % DISABLE_GL_DRAW_ARG, '')
       self.args = self.args.replace(DISABLE_GL_DRAW_ARG, '')
 
@@ -437,8 +437,8 @@ class BaseReproducer(object):
                 'The stacktrace seems similar to the original stacktrace.\n'
                 "Since you've reproduced the crash correctly, there are some "
                 'tricks that might help you move faster:\n'
-                '- In case of fixing the crash, you can use `--current` to run on '
-                'tip-of-tree (or, in other words, avoid git-checkout).\n'
+                '- In case of fixing the crash, you can use `--current` to run '
+                'on tip-of-tree (or, in other words, avoid git-checkout).\n'
                 '- You can save time by using `--skip-deps` to avoid '
                 '`gclient sync`, `gclient runhooks`, and other dependency '
                 'installations in subsequential runs.\n'

--- a/tool/tests/clusterfuzz/reproducers_test.py
+++ b/tool/tests/clusterfuzz/reproducers_test.py
@@ -358,7 +358,8 @@ class SetupArgsTest(helpers.ExtendedTestCase):
     self.provider.get_build_dir_path.return_value = '/chrome/source/folder'
     self.definition = mock.Mock()
     self.mock.update_for_gdb_if_needed.side_effect = (
-        lambda binary_path, args, timeout, should_enable_gdb: (binary_path, args, timeout)
+        lambda binary_path, args, timeout, should_enable_gdb:
+        (binary_path, args, timeout)
     )
     self.mock.edit_if_needed.side_effect = (
         lambda content, prefix, comment, should_edit: content)


### PR DESCRIPTION
This avoids: 

```
13:23:22 00:00         [chroot]**** Failed to install cryptography-2.1.3 (caused by: NonZeroExit("received exit code 1 during execution of `[u'/usr/bin/python2.7', '-', 'bdist_wheel', '--dist-dir=/tmp/tmp68gqf2']`",)
):
stdout:

stderr:
error in cryptography setup command: Invalid environment marker: python_version < '3'
```

When running test.

However, the new version of Pants seems to use a broken version of pytest. See: https://github.com/pantsbuild/pants/issues/5310 -- when running test, we need to add `-- -p no:logging`.