### PR TITLE
Upgrade pants to v1.9.0 to fix Mac builds

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -1,2 +1,2 @@
 [GLOBAL]
-pants_version: 1.3.0
+pants_version: 1.9.0

--- a/tool/BUILD
+++ b/tool/BUILD
@@ -33,9 +33,16 @@ python_library(
         '//3rdparty/python:xvfbwrapper',
         '//cmd-editor:src',
         '//error:src',
+        ':resources',
     ],
-    resources=rglobs('clusterfuzz/resources/*'),
     compatibility=['>=2.7','<3'],
+)
+
+
+resources(
+    name='resources',
+    description='Files included in the bundled application',
+    sources=rglobs('clusterfuzz/resources/*')
 )
 
 


### PR DESCRIPTION
Originally, the intent was to update to 1.9.0 to include fixes from
pants#6591, however the fixes aren't actually included in
1.9.0, and it may be necessary to use 1.11.0 or 1.12.0 to get the
full benefits.

In spite of this, at least locally, clusterfuzz-tools builds happily
under 1.9.0, so this may be enough to get things working under
MacOS Mojave.

Closes #538