### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/butler/butler/commands/release.py
+++ b/butler/butler/commands/release.py
@@ -1,4 +1,5 @@
 """Make a release."""
+from __future__ import print_function
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,8 +24,8 @@ BASH_RESET_MARKER = '\033[0m'
 
 def run(cmd):
   """Run the command."""
-  print
-  print '%s%s%s' %(BASH_BLUE_MARKER, cmd, BASH_RESET_MARKER)
+  print()
+  print('%s%s%s' %(BASH_BLUE_MARKER, cmd, BASH_RESET_MARKER))
 
   subprocess.check_call(cmd, shell=True, env=os.environ.copy())
 

--- a/ci/continuous_integration/daemon/main.py
+++ b/ci/continuous_integration/daemon/main.py
@@ -1,4 +1,5 @@
 """The main module for the CI server."""
+from __future__ import print_function
 
 import collections
 import os
@@ -108,7 +109,7 @@ def update_auth_header():
 
   with open(AUTH_FILE_LOCATION, 'w') as f:
     f.write('Bearer %s' % new_auth_token.access_token)
-  os.chmod(AUTH_FILE_LOCATION, 0600)
+  os.chmod(AUTH_FILE_LOCATION, 0o600)
 
 
 def get_binary_version():
@@ -167,12 +168,12 @@ def load_new_testcases():
 
     for testcase in items:
       if testcase['jobType'] not in supported_jobtypes['chromium']:
-        print 'Skip %s (%s) because its job type is not supported.' % (
-            testcase['id'], testcase['jobType'])
+        print('Skip %s (%s) because its job type is not supported.' % (
+            testcase['id'], testcase['jobType']))
         continue
 
       if not is_time_valid(int(testcase['timestamp'])):
-        print "Skip %s because it's too old." % testcase['id']
+        print("Skip %s because it's too old." % testcase['id'])
         continue
 
       if (testcase['id'] in PROCESSED_TESTCASE_IDS or
@@ -311,7 +312,7 @@ def main():
     testcases = load_new_testcases()
 
     if not testcases:
-      print 'There is no more valid testcase. Exit.'
+      print('There is no more valid testcase. Exit.')
       break
 
     for testcase in testcases:

--- a/ci/continuous_integration/tests/daemon/main_test.py
+++ b/ci/continuous_integration/tests/daemon/main_test.py
@@ -220,7 +220,7 @@ class LoadNewTestcasesTest(helpers.ExtendedTestCase):
             json={'page': page, 'reproducible': 'yes',
                   'q': 'platform:linux', 'open': 'yes',
                   'project': 'chromium'})
-        for page in xrange(1, 17)
+        for page in range(1, 17)
     ])
 
 

--- a/shared/pylint_cli/main.py
+++ b/shared/pylint_cli/main.py
@@ -1,4 +1,5 @@
 """Run pylint of all changed."""
+from __future__ import print_function
 
 import sys
 import os
@@ -9,7 +10,7 @@ from pylint import lint
 def run_lint(path, pylintrc_path):
   """Run pylint and return exit code."""
   try:
-    print 'Linting: %s' % path
+    print('Linting: %s' % path)
     lint.Run(['--rcfile=%s' % pylintrc_path, path])
     return 0
   except SystemExit as e:
@@ -20,7 +21,7 @@ def main():
   """Get diff files and run pylint against them."""
   basedir = os.path.dirname(__file__)
   pylintrc_path = os.path.join(basedir, '.pylintrc')
-  print 'Pylintrc: %s' % pylintrc_path
+  print('Pylintrc: %s' % pylintrc_path)
 
   rootdir = os.path.join(basedir, '..')
 

--- a/shared/test_libs/helpers.py
+++ b/shared/test_libs/helpers.py
@@ -50,7 +50,7 @@ class ExtendedTestCase(fake_filesystem_unittest.TestCase):
   def assert_file_permissions(self, filename, permissions):
     """Assert that 'filename' has specific permissions"""
 
-    self.assertEqual(int(oct(os.stat(filename).st_mode & 0777)[-3:]),
+    self.assertEqual(int(oct(os.stat(filename).st_mode & 0o777)[-3:]),
                      permissions)
 
   def assert_n_calls(self, n, methods):

--- a/tool/clusterfuzz/android.py
+++ b/tool/clusterfuzz/android.py
@@ -75,7 +75,7 @@ def ensure_asan(android_libclang_dir_path, device_id):
       'Are you sure you want to install ASAN on the device %s?' % device_id)
 
   _, output = common.execute(
-      common.get_resource(0755, 'resources', 'asan_device_setup.sh'),
+      common.get_resource(0o755, 'resources', 'asan_device_setup.sh'),
       '--lib %s --device %s' % (android_libclang_dir_path, device_id),
       env={'ADB_PATH': common.check_binary('adb', cwd='.')},
       redirect_stderr_to_stdout=True,

--- a/tool/clusterfuzz/commands/reproduce.py
+++ b/tool/clusterfuzz/commands/reproduce.py
@@ -198,7 +198,7 @@ def get_supported_jobs():
       'chromium': {}}
 
   with open(common.get_resource(
-      0640, 'resources', 'supported_job_types.yml')) as stream:
+      0o640, 'resources', 'supported_job_types.yml')) as stream:
     job_types_yaml = yaml.load(stream)
 
   for build_type in ['standalone', 'chromium']:

--- a/tool/clusterfuzz/commands/supported_job_types.py
+++ b/tool/clusterfuzz/commands/supported_job_types.py
@@ -28,7 +28,7 @@ def execute():
   logger.debug('Printing supported job types')
 
   with open(common.get_resource(
-      0640, 'resources', 'supported_job_types.yml')) as stream:
+      0o640, 'resources', 'supported_job_types.yml')) as stream:
     supported_jobs = yaml.load(stream)
   to_print = {}
   for category in supported_jobs:

--- a/tool/clusterfuzz/common.py
+++ b/tool/clusterfuzz/common.py
@@ -36,6 +36,11 @@ from clusterfuzz import local_logging
 from clusterfuzz import output_transformer
 from error import error
 
+try:
+  raw_input
+except NameError:
+  raw_input = input
+
 RETRY_COUNT = 5
 RETRY_SLEEP_TIME = 3
 
@@ -197,7 +202,7 @@ def style(s, marker, reset_char):
 
 def get_version():
   """Print version."""
-  with open(get_resource(0640, 'resources', 'VERSION')) as f:
+  with open(get_resource(0o640, 'resources', 'VERSION')) as f:
     return f.read().strip()
 
 
@@ -232,13 +237,13 @@ def get_stored_auth_header():
   if not os.path.isfile(AUTH_HEADER_FILE):
     return None
 
-  can_group_access = bool(os.stat(AUTH_HEADER_FILE).st_mode & 0070)
-  can_other_access = bool(os.stat(AUTH_HEADER_FILE).st_mode & 0007)
+  can_group_access = bool(os.stat(AUTH_HEADER_FILE).st_mode & 0o070)
+  can_other_access = bool(os.stat(AUTH_HEADER_FILE).st_mode & 0o007)
 
   if can_group_access or can_other_access:
     raise error.PermissionsTooPermissiveError(
         AUTH_HEADER_FILE,
-        oct(os.stat(AUTH_HEADER_FILE).st_mode & 0777))
+        oct(os.stat(AUTH_HEADER_FILE).st_mode & 0o777))
 
   with open(AUTH_HEADER_FILE, 'r') as f:
     return f.read()

--- a/tool/clusterfuzz/output_transformer.py
+++ b/tool/clusterfuzz/output_transformer.py
@@ -1,5 +1,10 @@
 """Transform the output before printing on screen."""
 
+try:
+  xrange
+except NameError:
+  xrange = range
+
 
 class Base(object):
   """Transform output and send to the output function."""

--- a/tool/clusterfuzz/reproducers.py
+++ b/tool/clusterfuzz/reproducers.py
@@ -214,7 +214,7 @@ def symbolize(output, source_dir_path):
   asan_symbolizer_location = os.path.join(
       source_dir_path,
       os.path.join('tools', 'valgrind', 'asan', 'asan_symbolize.py'))
-  symbolizer_proxy_location = common.get_resource(0755,
+  symbolizer_proxy_location = common.get_resource(0o755,
                                                   'asan_symbolize_proxy.py')
 
   _, symbolized_out = common.execute(
@@ -293,7 +293,7 @@ class BaseReproducer(object):
     self.binary_path = binary_provider.get_binary_path()
     self.build_directory = binary_provider.get_build_dir_path()
     self.source_directory = binary_provider.get_source_dir_path()
-    self.symbolizer_path = common.get_resource(0755, 'resources',
+    self.symbolizer_path = common.get_resource(0o755, 'resources',
                                                'llvm-symbolizer')
     self.gestures = testcase.gestures
     self.timeout = TEST_TIMEOUT
@@ -323,7 +323,7 @@ class BaseReproducer(object):
             'UBSAN_OPTIONS': 'ubsan',
         }
         filename = common.get_resource(
-            0640, 'resources', 'suppressions',
+            0o640, 'resources', 'suppressions',
             '%s_suppressions.txt' % suppressions_map[variable])
         options['suppressions'] = filename
       env[variable] = serialize_sanitizer_options(options)
@@ -511,7 +511,7 @@ class Xvfb(object):
           ['blackbox'], env={
               'DISPLAY': display_name
           })
-    except OSError, e:
+    except OSError as e:
       if str(e) == '[Errno 2] No such file or directory':
         raise error.NotInstalledError('blackbox')
       raise

--- a/tool/clusterfuzz/stackdriver_logging.py
+++ b/tool/clusterfuzz/stackdriver_logging.py
@@ -45,7 +45,7 @@ def send_log(params, stacktrace=None):
   """Joins the params dict with info like user id and then sends logs."""
   scopes = ['https://www.googleapis.com/auth/logging.write']
   filename = common.get_resource(
-      0640, 'resources', 'clusterfuzz-tools-logging.json')
+      0o640, 'resources', 'clusterfuzz-tools-logging.json')
 
   credentials = ServiceAccountCredentials.from_json_keyfile_name(
       filename, scopes=scopes)

--- a/tool/tests/clusterfuzz/binary_providers_test.py
+++ b/tool/tests/clusterfuzz/binary_providers_test.py
@@ -145,7 +145,7 @@ class GetBinaryPathTest(helpers.ExtendedTestCase):
 
   def test_call(self):
     """Tests calling the method."""
-    self.mock.stat.return_value = mock.Mock(st_mode=0600)
+    self.mock.stat.return_value = mock.Mock(st_mode=0o600)
 
     build_dir = os.path.expanduser(os.path.join(
         '~', 'chrome_src', 'out', '12345_build'))
@@ -159,7 +159,7 @@ class GetBinaryPathTest(helpers.ExtendedTestCase):
     path = os.path.join(build_dir, 'd8')
     self.assertEqual(path, provider.get_binary_path())
     self.mock.stat.assert_called_once_with(path)
-    self.mock.chmod.assert_called_once_with(path, 0700)
+    self.mock.chmod.assert_called_once_with(path, 0o700)
 
 
 class DownloadedBinaryTest(helpers.ExtendedTestCase):

--- a/tool/tests/clusterfuzz/commands/supported_job_types_test.py
+++ b/tool/tests/clusterfuzz/commands/supported_job_types_test.py
@@ -19,6 +19,11 @@ import yaml
 from clusterfuzz.commands import supported_job_types
 from test_libs import helpers
 
+try:
+    reload
+except NameError:
+    from importlib import reload
+
 
 class ExecuteTest(helpers.ExtendedTestCase):
   """Tests the printing of supported job types."""

--- a/tool/tests/clusterfuzz/common_test.py
+++ b/tool/tests/clusterfuzz/common_test.py
@@ -681,18 +681,18 @@ class MemoizeTest(helpers.ExtendedTestCase):
   def test_memoize_module(self):
     """Test memoizing a module function."""
     result = dummy_memoize()
-    for _ in xrange(10):
+    for _ in range(10):
       self.assertEqual(result, dummy_memoize())
 
   def test_different_args(self):
     """Test memoizing different arguments."""
     dummy = DummyMemoize('a', 'b')
 
-    for _ in xrange(10):
+    for _ in range(10):
       self.assertEqual('ba', dummy.b('a'))
     self.assertEqual(1, dummy.b_execution_count)
 
-    for _ in xrange(10):
+    for _ in range(10):
       self.assertEqual('baaa', dummy.b('aaa'))
     self.assertEqual(2, dummy.b_execution_count)
 
@@ -701,7 +701,7 @@ class MemoizeTest(helpers.ExtendedTestCase):
     dummy_0 = DummyMemoize('a', 'b')
     dummy_1 = DummyMemoize('c', 'd')
 
-    for _ in xrange(0, 5):
+    for _ in range(5):
       self.assertEqual('a', dummy_0.a())
       self.assertEqual('bx', dummy_0.b('x'))
       self.assertEqual('c', dummy_1.a())


### PR DESCRIPTION
Use __print()__ function in both Python 2 and Python 3
* Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Old style exceptions --> new style for Python 3
* Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.